### PR TITLE
Makefile: Add node_modules/.bin to PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PATH := ./node_modules/.bin:$(PATH)
+
 target = public
 css_target = $(target)/css
 


### PR DESCRIPTION
Ensures that CUI is built with the coffee-script, codo etc. defined in package.json.